### PR TITLE
Don't call parent::handle() in the background job middleware

### DIFF
--- a/src/NewRelicBackgroundJobMiddleware.php
+++ b/src/NewRelicBackgroundJobMiddleware.php
@@ -20,6 +20,6 @@ class NewRelicBackgroundJobMiddleware extends NewRelicMiddleware
         // Mark the request as a background job
         $this->newRelic->backgroundJob();
 
-        return parent::handle($request, $next);
+        return $next($request);
     }
 }


### PR DESCRIPTION
This can cause odd issues with naming transactions. Tested in master, too hard to write working tests for all supported PHP versions here.