### PR TITLE
Enable setting license and application name via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The environment variables available are:
 * `NEW_RELIC_APP_NAME`
 * `NEW_RELIC_LICENSE_KEY`
 
-Check out the description in `/config/newRelic.ini` for an explanation of the effect.
+Check out the description in `/config/newRelic.php` for an explanation of the effect.
 
 ### Bootstrapping
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Run the following command to install the package through Composer:
 composer require nordsoftware/lumen-newrelic
 ```
 
+### Configuration
+
+You don't have to set any config values if you are happy to rely on the content of your `newrelic.ini` file. However,
+it's possible to override the license and application name using environment variables or the `.env` file. This can be
+useful if you deploy the same app in multiple environments, and therefore need distinguished names for each.
+
+The environment variables available are:
+
+* `NEW_RELIC_APP_NAME`
+* `NEW_RELIC_LICENSE_KEY`
+
+Check out the description in `/config/newRelic.ini` for an explanation of the effect.
+
 ### Bootstrapping
 
 In `bootstrap/app.php`, replace the `$app->singleton()` call which registers the exception handler with the following 

--- a/config/newRelic.php
+++ b/config/newRelic.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Name
+    |--------------------------------------------------------------------------
+    |
+    | This config option sets the application name that data is reported under
+    | in New Relic APM. New Relic highly recommends that you replace the
+    | default name with a descriptive name to avoid confusion and unintended
+    | aggregation of data. Data for all applications with the same name will
+    | be merged in the New Relic UI, so set this carefully.
+    |
+    | If none if provided, the value from newrelic.ini is used.
+    |
+    */
+    'application_name' => env('NEW_RELIC_APP_NAME', ini_get('newrelic.appname')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | License
+    |--------------------------------------------------------------------------
+    |
+    | Sets the New Relic license key to use. If this is not set, the New Relic
+    | module will not attempt to post data to its collectors.
+    |
+    | If none if provided, the value from newrelic.ini is used.
+    |
+    */
+    'license' => env('NEW_RELIC_LICENSE_KEY', ini_get('newrelic.license')),
+
+];

--- a/src/NewRelicMiddleware.php
+++ b/src/NewRelicMiddleware.php
@@ -43,6 +43,10 @@ class NewRelicMiddleware
         $response = $next($request);
 
         $this->newRelic->nameTransaction($this->getTransactionName($request));
+        $this->newRelic->setAppName(
+            config('newRelic.application_name'),
+            config('newRelic.license')
+        );
 
         return $response;
     }

--- a/src/NewRelicServiceProvider.php
+++ b/src/NewRelicServiceProvider.php
@@ -22,7 +22,7 @@ class NewRelicServiceProvider extends ServiceProvider
         });
 
         $this->mergeConfigFrom(
-            __DIR__.'/../config/newrelic.php', 'newRelic'
+            __DIR__.'/../config/newRelic.php', 'newRelic'
         );
     }
 

--- a/src/NewRelicServiceProvider.php
+++ b/src/NewRelicServiceProvider.php
@@ -20,6 +20,10 @@ class NewRelicServiceProvider extends ServiceProvider
         $this->app->singleton(Newrelic::class, function() {
             return new Newrelic();
         });
+
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/newrelic.php', 'newRelic'
+        );
     }
 
 }

--- a/src/NewRelicServiceProvider.php
+++ b/src/NewRelicServiceProvider.php
@@ -21,9 +21,11 @@ class NewRelicServiceProvider extends ServiceProvider
             return new Newrelic();
         });
 
-        $this->mergeConfigFrom(
-            __DIR__.'/../config/newRelic.php', 'newRelic'
-        );
+        if (\file_exists(__DIR__.'/../config/newRelic.php')) {
+            $this->mergeConfigFrom(
+                __DIR__.'/../config/newRelic.php', 'newRelic'
+            );
+        }
 
         // This will make sure to not call configure() on non-Lumen apps
         if ($this->app instanceof \Laravel\Lumen\Application) {

--- a/src/NewRelicServiceProvider.php
+++ b/src/NewRelicServiceProvider.php
@@ -24,6 +24,11 @@ class NewRelicServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/../config/newRelic.php', 'newRelic'
         );
+
+        // This will make sure to not call configure() on non-Lumen apps
+        if ($this->app instanceof \Laravel\Lumen\Application) {
+            $this->app->configure('newRelic');
+        }
     }
 
 }


### PR DESCRIPTION
Changes proposed in this pull request:

 * Enable setting New Relic license and application name via `.env` / environment variables

The reason for this in my case is that I run my app in Docker containers, and so the same image is used on multiple environments. However, I need those different environments to appear as separate apps in New Relic, and so I pass in an app name and license which reflects the environment.

If the env vars are not defined, it will fall through to using the values found in the `php.ini` file or its includes.

I've added docs to explain to newcomers too :)