### PR TITLE
Add new newRelic.override_ini setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ You don't have to set any config values if you are happy to rely on the content 
 it's possible to override the license and application name using environment variables or the `.env` file. This can be
 useful if you deploy the same app in multiple environments, and therefore need distinguished names for each.
 
+Be aware that doing so can have a [small performance impact](https://github.com/In-Touch/newrelic/blob/5dc4eb7a25731f92cdbfb7a094a788cf137df40e/src/Newrelic.php#L82-L87) on the app
+
 The environment variables available are:
 
+* `NEW_RELIC_OVERRIDE_INI` (defaults to `false`)
 * `NEW_RELIC_APP_NAME`
 * `NEW_RELIC_LICENSE_KEY`
+
+If you don't set `NEW_RELIC_OVERRIDE_INI` to `true`, the app will not override the `newrelic.ini` file, regardless of the 
+value of the other two variables.
 
 Check out the description in `/config/newRelic.php` for an explanation of the effect.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You don't have to set any config values if you are happy to rely on the content 
 it's possible to override the license and application name using environment variables or the `.env` file. This can be
 useful if you deploy the same app in multiple environments, and therefore need distinguished names for each.
 
-Be aware that doing so can have a [small performance impact](https://github.com/In-Touch/newrelic/blob/5dc4eb7a25731f92cdbfb7a094a788cf137df40e/src/Newrelic.php#L82-L87) on the app
+Be aware that doing so can have a [small performance impact](https://github.com/In-Touch/newrelic/blob/5dc4eb7a25731f92cdbfb7a094a788cf137df40e/src/Newrelic.php#L82-L87) on the app.
 
 The environment variables available are:
 

--- a/config/newRelic.php
+++ b/config/newRelic.php
@@ -4,6 +4,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Override newrelic.ini
+    |--------------------------------------------------------------------------
+    |
+    | This config option enables overriding the application name and license 
+    | specified in the newrelic.ini file. This is useful for cases where you 
+    | cannot set the contents of newrelic.ini, or when you have a multi-site 
+    | server and each site to appear separately in NewRelic.
+    |
+    | As naming is done on a per transaction basis, and can have a performance
+    | impact on the app, this setting defaults to false and must be manally
+    | overridden.
+    | 
+    */
+    'override_ini' => env('NEW_RELIC_OVERRIDE_INI', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Name
     |--------------------------------------------------------------------------
     |

--- a/src/NewRelicMiddleware.php
+++ b/src/NewRelicMiddleware.php
@@ -43,10 +43,14 @@ class NewRelicMiddleware
         $response = $next($request);
 
         $this->newRelic->nameTransaction($this->getTransactionName($request));
-        $this->newRelic->setAppName(
-            config('newRelic.application_name'),
-            config('newRelic.license')
-        );
+
+        if (config('newRelic.override_ini')) {
+            $this->newRelic->setAppName(
+                config('newRelic.application_name'),
+                config('newRelic.license'),
+                true
+            );
+        }
 
         return $response;
     }


### PR DESCRIPTION
Add new newRelic.override_ini to gate overriding the app name and license in the newrelic.ini file.
Update docs to include detail on possible slight performance impact and new environment variable

Fixes #26 

Changes proposed in this pull request:

 * Add new `NEW_RELIC_OVERRIDE_INI` / `newRelic.override_ini` setting to gate overriding the appName and licence details from the `newrelic.ini` file
