### PR TITLE
Fix signature warning in tests

### DIFF
--- a/tests/NewRelicExceptionHandlerTest.php
+++ b/tests/NewRelicExceptionHandlerTest.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use Nord\Lumen\NewRelic\NewRelicExceptionHandler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
 /**
  * Class NewRelicExceptionHandlerTest
@@ -73,7 +74,7 @@ class TestNewRelicExceptionHandler extends NewRelicExceptionHandler
     /**
      * @inheritdoc
      */
-    protected function logException(Exception $e)
+    protected function logException(Throwable $e)
     {
         // Used to indicate that this method was actually executed
         throw $e;


### PR DESCRIPTION
This will fix the [following warning in the tests](https://github.com/digiaonline/lumen-newrelic/runs/1399306129).

```
PHP Warning:  Declaration of Nord\Lumen\NewRelic\Tests\TestNewRelicExceptionHandler::logException(Exception $e) should be compatible with Nord\Lumen\NewRelic\NewRelicExceptionHandler::logException(Throwable $e) in /home/runner/work/lumen-newrelic/lumen-newrelic/tests/NewRelicExceptionHandlerTest.php on line 76
```

