### PR TITLE
Upgrade intouch/newrelic to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "intouch/newrelic": "^1.0",
+        "intouch/newrelic": "^1.0 | ^2.0",
         "illuminate/support": "^5.5 | ^6.0 | ^7.0 | ^8.0",
         "nordsoftware/lumen-chained-exception-handler": "^2.0"
     },


### PR DESCRIPTION
Existing installation can still use v1, I did not notice breaking changes
between the two versions that impact this library.

[v2 of the library](https://github.com/In-Touch/newrelic/blob/master/CHANGELOG.md) allows to record custom events, which is the feature I am interested in.

Note that v2 drops PHP5 support.