### PR TITLE
Support for PHP 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["7.2", "7.3", "7.4"]
+        php-version: ["7.3", "7.4", "8.0"]
         os: [ubuntu-latest]
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "intouch/newrelic": "^1.0",
+        "php": "^7.2 | ^8.0",
+        "intouch/newrelic": "^1.0 | ^2.0",
         "illuminate/support": "^5.5 | ^6.0 | ^7.0 | ^8.0",
-        "nordsoftware/lumen-chained-exception-handler": "^2.0"
+        "nordsoftware/lumen-chained-exception-handler": "^3.0"
     },
     "require-dev": {
         "laravel/lumen-framework": "^5.5|^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9"
     },
     "autoload": {
         "psr-4": {

--- a/tests/NewRelicExceptionHandlerTest.php
+++ b/tests/NewRelicExceptionHandlerTest.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use Nord\Lumen\NewRelic\NewRelicExceptionHandler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
 /**
  * Class NewRelicExceptionHandlerTest
@@ -17,12 +18,11 @@ class NewRelicExceptionHandlerTest extends TestCase
 
     /**
      * Tests that exceptions that are not on the ignore list get reported
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage testReportException
      */
     public function testReportException()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("testReportException");
         $handler = new TestNewRelicExceptionHandler();
         $handler->report(new Exception('testReportException'));
     }
@@ -50,13 +50,10 @@ class NewRelicExceptionHandlerTest extends TestCase
 
         $this->addToAssertionCount(1);
     }
-
-
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
+    
     public function testIgnoreNothing()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
         $handler = new TestNewRelicExceptionHandler([]);
         $handler->report(new NotFoundHttpException());
     }
@@ -73,7 +70,7 @@ class TestNewRelicExceptionHandler extends NewRelicExceptionHandler
     /**
      * @inheritdoc
      */
-    protected function logException(Exception $e)
+    protected function logException(Throwable $e)
     {
         // Used to indicate that this method was actually executed
         throw $e;

--- a/tests/NewRelicServiceProviderTest.php
+++ b/tests/NewRelicServiceProviderTest.php
@@ -54,6 +54,6 @@ class NewRelicServiceProviderTest extends TestCase
         // registered correctly)
         $response = $app->handle(Request::create('/', 'GET'));
         $this->assertEquals(550, $response->getStatusCode());
-        $this->assertContains('Whoops, looks like something went wrong', $response->getContent());
+        $this->assertStringContainsString('Whoops, looks like something went wrong', $response->getContent());
     }
 }


### PR DESCRIPTION
Fixes #31

Changes proposed in this pull request:

 * Update supported PHP version to include PHP 8
 * **Currently blocked by New Relic team: the NewRelic agent for PHP is only working with PHP up to 7.4**
 * **Also blocked by https://github.com/digiaonline/lumen-chained-exception-handler/pull/11**
 
```
  - Installing intouch/newrelic (1.0.3): Extracting archive
  - Installing nordsoftware/lumen-newrelic (dev-php8 260b10b): Extracting archive
  - Installing phpdocumentor/reflection-common (2.2.0): Extracting archive
```
